### PR TITLE
Add support for Counter-Strike: Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The plugin creates the following console variables:
 * `vehicle_physics_damage_modifier ( def. "1.0" )` - Modifier of impact-based physics damage against other players
 * `vehicle_passenger_damage_modifier ( def. "1.0" )` - Modifier of damage dealt to vehicle passengers
 * `vehicle_enable_entry_exit_anims ( def. "0" )` - If set to 1, enables entry and exit animations (experimental)
-* `vehicle_allow_horns ( def. "1" )` - If set to 1, enables vehicle horns
+* `vehicle_enable_horns ( def. "1" )` - If set to 1, enables vehicle horns
 
 ## Physics Damage
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Driveable Vehicles
+# Driveable Vehicles for Source Engine Multiplayer
 
 This is a SourceMod plugin that allows spawning driveable vehicles based on `prop_vehicle_driveable` in Source engine
 multiplayer games.
 
-**Supported games:**
+**List of supported games:**
 
 * Team Fortress 2
 * Counter-Strike: Source
@@ -30,7 +30,7 @@ This plugin bundles the required entity fixes, and a few configurable nice-to-ha
 
 ## Installation
 
-1. Download the latest version from the [releases](https://github.com/Mikusch/mp-vehicles/releases) page
+1. Download the latest version from the [releases](https://github.com/Mikusch/source-vehicles/releases) page
 2. Extract the contents of the ZIP file into your server's game directory
 3. Restart your server or type `sm plugins load vehicles` into your server console
 
@@ -40,6 +40,8 @@ There is a menu combining all the plugin's features that can be accessed using `
 
 Additionally, you may use `sm_createvehicle` to create and `sm_removevehicle` to remove a vehicle. To remove all
 vehicles in the map, use `sm_removeallvehicles`.
+
+To enter a vehicle, look at it and use the `+use` console command.
 
 ## Configuration
 
@@ -57,15 +59,15 @@ the [Vehicle Scripts for Source](https://steamcommunity.com/sharedfiles/filedeta
 {
 	"0"
 	{
-		"id"					"example_vehicle"
-		"name"					"#Vehicle_ExampleVehicle"
-		"model"					"models/vehicles/example_vehicle.mdl"
-		"script"				"scripts/vehicles/example_vehicle.txt"
-		"type"					"car_wheels"
-		"skins"					"0,1,2"
-		"key_hint"				"#Hint_VehicleKeys_Car"
+		"id"				"example_vehicle"
+		"name"				"#Vehicle_ExampleVehicle"
+		"model"				"models/vehicles/example_vehicle.mdl"
+		"script"			"scripts/vehicles/example_vehicle.txt"
+		"type"				"car_wheels"
+		"skins"				"0,1,2"
+		"key_hint"			"#Hint_VehicleKeys_Car"
 		"lock_speed"			"10.0"
-		"is_passenger_visible"	"1"
+		"is_passenger_visible"		"1"
 		"horn_sound"			"sounds/vehicles/example_horn.wav"
 		"downloads"
 		{

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-# Driveable Vehicles for Team Fortress 2
+# Driveable Vehicles
 
-This is a plugin that allows spawning driveable vehicles based on `prop_vehicle_driveable` in Team Fortress 2.
+This is a SourceMod plugin that allows spawning driveable vehicles based on `prop_vehicle_driveable` in Source engine
+multiplayer games.
 
-While this has surely been done before, the implementation of this plugin is vastly different. Instead of simulating user input on
-the vehicle through the entity inputs, it forwards your user input directly to the vehicle, making driving feel incredibly smooth.
+**Supported games:**
 
-This plugin bundles the required entity fixes and a few configurable nice-to-have features.
+* Team Fortress 2
+* Counter-Strike: Source
+
+While this has been done before, the implementation of this plugin is vastly different. Instead of simulating user input
+on the vehicle through the entity inputs, it forwards your user input directly to the vehicle, making driving feel
+incredibly smooth.
+
+This plugin bundles the required entity fixes, and a few configurable nice-to-have features.
 
 ## Features
 
@@ -23,21 +30,21 @@ This plugin bundles the required entity fixes and a few configurable nice-to-hav
 
 ## Installation
 
-1. Download the latest version from the [releases](https://github.com/Mikusch/tf-vehicles/releases) page
-2. Extract the contents of the ZIP file into your server's `tf` directory
+1. Download the latest version from the [releases](https://github.com/Mikusch/mp-vehicles/releases) page
+2. Extract the contents of the ZIP file into your server's game directory
 3. Restart your server or type `sm plugins load vehicles` into your server console
 
 ## Usage
 
-There is a menu combining all of the plugin's features that can be accessed using `sm_vehicle`.
+There is a menu combining all the plugin's features that can be accessed using `sm_vehicle`.
 
-Additionally, you may use `sm_createvehicle` to create and `sm_removevehicle` to remove a vehicle. To remove all vehicles in the
-map, use `sm_removeallvehicles`.
+Additionally, you may use `sm_createvehicle` to create and `sm_removevehicle` to remove a vehicle. To remove all
+vehicles in the map, use `sm_removeallvehicles`.
 
 ## Configuration
 
-The vehicle configuration allows you to add custom vehicles. Each vehicle requires at least a name, model, vehicle script, and
-vehicle type. More documentation and examples can be found in
+The vehicle configuration allows you to add custom vehicles. Each vehicle requires at least a name, model, vehicle
+script, and vehicle type. More documentation and examples can be found in
 the [default configuration](/addons/sourcemod/configs/vehicles/vehicles.cfg).
 
 To learn how to create custom vehicle models and scripts, check out
@@ -79,28 +86,27 @@ the [Vehicle Scripts for Source](https://steamcommunity.com/sharedfiles/filedeta
 
 The plugin creates the following console variables:
 
-* `tf_vehicle_config ( def. "configs/vehicles/vehicles.cfg" )` - Configuration file to read all vehicles from, relative to the SourceMod folder
-* `tf_vehicle_physics_damage_modifier ( def. "1.0" )` - Modifier of impact-based physics damage against other players
-* `tf_vehicle_passenger_damage_modifier ( def. "1.0" )` - Modifier of damage dealt to vehicle passengers
-* `tf_vehicle_voicemenu_use ( def. "1" )` - Allow the 'MEDIC!' voice menu command to call +use
-* `tf_vehicle_enable_entry_exit_anims ( def. "0" )` - Enable entry and exit animations (experimental)
-* `tf_vehicle_allow_horns ( def. "1" )` - Allow players to use vehicle horns
+* `vehicle_config_path ( def. "configs/vehicles/vehicles.cfg" )` - Path to vehicle configuration file, relative to the SourceMod folder
+* `vehicle_physics_damage_modifier ( def. "1.0" )` - Modifier of impact-based physics damage against other players
+* `vehicle_passenger_damage_modifier ( def. "1.0" )` - Modifier of damage dealt to vehicle passengers
+* `vehicle_enable_entry_exit_anims ( def. "0" )` - If set to 1, enables entry and exit animations (experimental)
+* `vehicle_allow_horns ( def. "1" )` - If set to 1, enables vehicle horns
 
 ## Physics Damage
 
 This plugin will automatically enable physics collisions and damage to allow vehicles to collide with other players.
 
-If you intend to use these vehicles in a friendly environment without any combat aspects, set `sv_turbophysics` to `1`. It will
-allow vehicles to pass through other players.
+If you intend to use these vehicles in a friendly environment without any combat aspects, set `sv_turbophysics` to `1`.
+It will allow vehicles to pass through other players.
 
 ## Entry and Exit Animations
 
-Most vehicles have entry and exit animations that make the player transition between the vehicle and the entry/exit points. The plugin
-fully supports these animations.
+Most vehicles have entry and exit animations that make the player transition between the vehicle and the entry/exit
+points. The plugin fully supports these animations.
 
-However, since Valve never intended `prop_vehicle_driveable` to be used outside of Half-Life 2, there is code that does not
+However, since Valve never intended `prop_vehicle_driveable` to be used outside Half-Life 2, there is code that does not
 function properly in a multiplayer environment and can even cause client crashes.
 
 Because of that, entry and exit animations on all vehicles are disabled by default and have to be manually enabled by
-setting `tf_vehicle_enable_entry_exit_anims` to `1`. If you intend to use this plugin on a public server, it is **highly
+setting `vehicle_enable_entry_exit_anims` to `1`. If you intend to use this plugin on a public server, it is **highly
 recommended** to keep the animations disabled.

--- a/addons/sourcemod/configs/vehicles/vehicles.cfg
+++ b/addons/sourcemod/configs/vehicles/vehicles.cfg
@@ -14,7 +14,7 @@
 //  [key_hint]				- Key hint displayed to the player entering the vehicle (defined in vehicles.phrases.txt) (def. "")
 //  [lock_speed]			- Vehicle must be going slower than this for player to enter or exit, in in/sec (def. "10.0")
 //  [is_passenger_visible]	- Whether the vehicle passenger is visible (def. "1")
-//  [horn_sound]			- Custom horn sound, supports looping sounds (def. "ambient_mp3/mvm_warehouse/car_horn_03.mp3")
+//  [horn_sound]			- Custom horn sound, supports looping sounds (def. "")
 //  [downloads]				- List of files that should be added to the downloads table for clients to download
 //
 "Vehicles"

--- a/addons/sourcemod/gamedata/vehicles.txt
+++ b/addons/sourcemod/gamedata/vehicles.txt
@@ -1,7 +1,13 @@
 "Games"
 {
-	"tf"
+	"#default"
 	{
+		"#supported"
+		{
+			"game"	"tf"
+			"game"	"cstrike"
+		}
+		
 		"Signatures"
 		{
 			"CPlayerMove::SetupMove"
@@ -20,6 +26,7 @@
 				//FIXME: The signature for CBaseAnimating::GetAttachmentLocal is inlined on Windows
 			}
 		}
+		
 		"Offsets"
 		{
 			"CBaseServerVehicle::SetupMove"
@@ -62,22 +69,8 @@
 				"linux"		"22"
 				"windows"	"22"
 			}
-			"CBaseAnimating::StudioFrameAdvance"
-			{
-				"linux"		"194"
-				"windows"	"193"
-			}
-			"CBasePlayer::GetInVehicle"
-			{
-				"linux"		"397"
-				"windows"	"396"
-			}
-			"CBasePlayer::LeaveVehicle"
-			{
-				"linux"		"398"
-				"windows"	"397"
-			}
 		}
+		
 		"Functions"
 		{
 			"CPlayerMove::SetupMove"
@@ -223,6 +216,50 @@
 						"type"	"vectorptr"
 					}
 				}
+			}
+		}
+	}
+	
+	"tf"
+	{
+		"Offsets"
+		{
+			"CBaseAnimating::StudioFrameAdvance"
+			{
+				"linux"		"194"
+				"windows"	"193"
+			}
+			"CBasePlayer::GetInVehicle"
+			{
+				"linux"		"397"
+				"windows"	"396"
+			}
+			"CBasePlayer::LeaveVehicle"
+			{
+				"linux"		"398"
+				"windows"	"397"
+			}
+		}
+	}
+	
+	"cstrike"
+	{
+		"Offsets"
+		{
+			"CBaseAnimating::StudioFrameAdvance"
+			{
+				"linux"		"191"
+				"windows"	"190"
+			}
+			"CBasePlayer::GetInVehicle"
+			{
+				"linux"		"394"
+				"windows"	"393"
+			}
+			"CBasePlayer::LeaveVehicle"
+			{
+				"linux"		"395"
+				"windows"	"394"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -244,9 +244,6 @@ public Plugin myinfo =
 
 public void OnPluginStart()
 {
-	if (GetEngineVersion() != Engine_TF2)
-		SetFailState("This plugin is only compatible with Team Fortress 2");
-	
 	LoadTranslations("common.phrases");
 	LoadTranslations("vehicles.phrases");
 	

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -179,7 +179,6 @@ ArrayList g_VehicleProperties;
 char g_OldAllowPlayerUse[8];
 char g_OldTurboPhysics[8];
 
-bool g_ClientInUse[MAXPLAYERS + 1];
 bool g_ClientIsUsingHorn[MAXPLAYERS + 1];
 
 methodmap Vehicle
@@ -361,7 +360,6 @@ public void OnClientPutInServer(int client)
 {
 	DHookClient(client);
 	SDKHook(client, SDKHook_OnTakeDamage, Client_OnTakeDamage);
-	g_ClientInUse[client] = false;
 	g_ClientIsUsingHorn[client] = false;
 }
 
@@ -390,13 +388,6 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 				}
 			}
 		}
-	}
-	
-	if (g_ClientInUse[client])
-	{
-		g_ClientInUse[client] = !g_ClientInUse[client];
-		buttons |= IN_USE;
-		return Plugin_Changed;
 	}
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -28,7 +28,7 @@
 
 #define PLUGIN_VERSION	"1.9.0"
 #define PLUGIN_AUTHOR	"Mikusch"
-#define PLUGIN_URL		"https://github.com/Mikusch/tf-vehicles"
+#define PLUGIN_URL		"https://github.com/Mikusch/mp-vehicles"
 
 #define VEHICLE_CLASSNAME	"prop_vehicle_driveable"
 
@@ -147,12 +147,11 @@ enum struct VehicleProperties
 	}
 }
 
-ConVar tf_vehicle_config;
-ConVar tf_vehicle_physics_damage_modifier;
-ConVar tf_vehicle_passenger_damage_modifier;
-ConVar tf_vehicle_voicemenu_use;
-ConVar tf_vehicle_enable_entry_exit_anims;
-ConVar tf_vehicle_allow_horns;
+ConVar vehicle_config_path;
+ConVar vehicle_physics_damage_modifier;
+ConVar vehicle_passenger_damage_modifier;
+ConVar vehicle_enable_entry_exit_anims;
+ConVar vehicle_enable_horns;
 
 GlobalForward g_ForwardOnVehicleSpawned;
 GlobalForward g_ForwardOnVehicleDestroyed;
@@ -231,9 +230,9 @@ methodmap Vehicle
 
 public Plugin myinfo = 
 {
-	name = "Driveable Vehicles for Team Fortress 2", 
+	name = "Driveable Vehicles", 
 	author = PLUGIN_AUTHOR, 
-	description = "Fully functioning driveable vehicles for Team Fortress 2", 
+	description = "Fully functioning driveable vehicles", 
 	version = PLUGIN_VERSION, 
 	url = PLUGIN_URL
 }
@@ -262,13 +261,12 @@ public void OnPluginStart()
 	}
 	
 	//Create plugin convars
-	tf_vehicle_config = CreateConVar("tf_vehicle_config", "configs/vehicles/vehicles.cfg", "Configuration file to read all vehicles from, relative to the SourceMod folder");
-	tf_vehicle_config.AddChangeHook(ConVarChanged_RefreshVehicleConfig);
-	tf_vehicle_physics_damage_modifier = CreateConVar("tf_vehicle_physics_damage_modifier", "1.0", "Modifier of impact-based physics damage against other players", _, true, 0.0);
-	tf_vehicle_passenger_damage_modifier = CreateConVar("tf_vehicle_passenger_damage_modifier", "1.0", "Modifier of damage dealt to vehicle passengers", _, true, 0.0);
-	tf_vehicle_voicemenu_use = CreateConVar("tf_vehicle_voicemenu_use", "1", "Allow the 'MEDIC!' voice menu command to call +use");
-	tf_vehicle_enable_entry_exit_anims = CreateConVar("tf_vehicle_enable_entry_exit_anims", "0", "Enable entry and exit animations (experimental)");
-	tf_vehicle_allow_horns = CreateConVar("tf_vehicle_allow_horns", "1", "Allow players to use vehicle horns");
+	vehicle_config_path = CreateConVar("vehicle_config_path", "configs/vehicles/vehicles.cfg", "Path to vehicle configuration file, relative to the SourceMod folder");
+	vehicle_config_path.AddChangeHook(ConVarChanged_RefreshVehicleConfig);
+	vehicle_physics_damage_modifier = CreateConVar("vehicle_physics_damage_modifier", "1.0", "Modifier of impact-based physics damage against other players", _, true, 0.0);
+	vehicle_passenger_damage_modifier = CreateConVar("vehicle_passenger_damage_modifier", "1.0", "Modifier of damage dealt to vehicle passengers", _, true, 0.0);
+	vehicle_enable_entry_exit_anims = CreateConVar("vehicle_enable_entry_exit_anims", "0", "If set to 1, enables entry and exit animations (experimental)");
+	vehicle_enable_horns = CreateConVar("vehicle_enable_horns", "1", "If set to 1, enables vehicle horns");
 	
 	RegAdminCmd("sm_vehicle", ConCmd_OpenVehicleMenu, ADMFLAG_GENERIC);
 	RegAdminCmd("sm_vehicles", ConCmd_OpenVehicleMenu, ADMFLAG_GENERIC);
@@ -278,8 +276,6 @@ public void OnPluginStart()
 	RegAdminCmd("sm_removevehicle", ConCmd_DestroyVehicle, ADMFLAG_GENERIC);
 	RegAdminCmd("sm_destroyallvehicles", ConCmd_DestroyAllVehicles, ADMFLAG_GENERIC);
 	RegAdminCmd("sm_removeallvehicles", ConCmd_DestroyAllVehicles, ADMFLAG_GENERIC);
-	
-	AddCommandListener(CommandListener_VoiceMenu, "voicemenu");
 	
 	Vehicle.InitializePropertyList();
 	
@@ -371,7 +367,7 @@ public void OnClientPutInServer(int client)
 
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2])
 {
-	if (tf_vehicle_allow_horns.BoolValue)
+	if (vehicle_enable_horns.BoolValue)
 	{
 		int vehicle = GetEntPropEnt(client, Prop_Data, "m_hVehicle");
 		if (vehicle != -1)
@@ -573,7 +569,7 @@ void ReadVehicleConfig()
 	
 	//Build path to config file
 	char file[PLATFORM_MAX_PATH], path[PLATFORM_MAX_PATH];
-	tf_vehicle_config.GetString(file, sizeof(file));
+	vehicle_config_path.GetString(file, sizeof(file));
 	BuildPath(Path_SM, path, sizeof(path), file);
 	
 	//Read the vehicle configuration
@@ -806,21 +802,6 @@ public Action Timer_ShowVehicleKeyHint(Handle timer, int vehicleRef)
 // Commands
 //-----------------------------------------------------------------------------
 
-public Action CommandListener_VoiceMenu(int client, const char[] command, int args)
-{
-	if (tf_vehicle_voicemenu_use.BoolValue)
-	{
-		char arg1[2], arg2[2];
-		GetCmdArg(1, arg1, sizeof(arg1));
-		GetCmdArg(2, arg2, sizeof(arg2));
-		
-		if (arg1[0] == '0' && arg2[0] == '0')	//MEDIC!
-		{
-			g_ClientInUse[client] = true;
-		}
-	}
-}
-
 public Action ConCmd_OpenVehicleMenu(int client, int args)
 {
 	if (client == 0)
@@ -929,7 +910,7 @@ public Action Client_OnTakeDamage(int victim, int &attacker, int &inflictor, flo
 		int driver = GetEntPropEnt(inflictor, Prop_Data, "m_hPlayer");
 		if (driver != -1 && victim != driver)
 		{
-			damage *= tf_vehicle_physics_damage_modifier.FloatValue;
+			damage *= vehicle_physics_damage_modifier.FloatValue;
 			attacker = driver;
 			return Plugin_Changed;
 		}
@@ -971,7 +952,7 @@ public Action PropVehicleDriveable_OnTakeDamage(int vehicle, int &attacker, int 
 			return Plugin_Continue;
 		
 		//Scale the damage
-		SDKHooks_TakeDamage(client, inflictor, attacker, damage * tf_vehicle_passenger_damage_modifier.FloatValue, damagetype | DMG_VEHICLE, weapon, damageForce, damagePosition);
+		SDKHooks_TakeDamage(client, inflictor, attacker, damage * vehicle_passenger_damage_modifier.FloatValue, damagetype | DMG_VEHICLE, weapon, damageForce, damagePosition);
 	}
 	
 	return Plugin_Continue;
@@ -1251,7 +1232,7 @@ public MRESReturn DHookCallback_IsPassengerVisiblePost(Address serverVehicle, DH
 
 public MRESReturn DHookCallback_HandlePassengerEntryPre(Address serverVehicle, DHookParam params)
 {
-	if (!tf_vehicle_enable_entry_exit_anims.BoolValue)
+	if (!vehicle_enable_entry_exit_anims.BoolValue)
 	{
 		int client = params.Get(1);
 		int vehicle = SDKCall_GetVehicleEnt(serverVehicle);
@@ -1279,7 +1260,7 @@ public MRESReturn DHookCallback_HandlePassengerEntryPre(Address serverVehicle, D
 
 public MRESReturn DHookCallback_GetExitAnimToUsePost(Address serverVehicle, DHookReturn ret)
 {
-	if (!tf_vehicle_enable_entry_exit_anims.BoolValue)
+	if (!vehicle_enable_entry_exit_anims.BoolValue)
 	{
 		ret.Value = ACTIVITY_NOT_AVAILABLE;
 		return MRES_Override;

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -100,7 +100,7 @@ enum struct VehicleConfig
 		kv.GetString("key_hint", this.key_hint, 256);
 		this.is_passenger_visible = view_as<bool>(kv.GetNum("is_passenger_visible", true));
 		
-		kv.GetString("horn_sound", this.horn_sound, PLATFORM_MAX_PATH, "ambient_mp3/mvm_warehouse/car_horn_03.mp3");
+		kv.GetString("horn_sound", this.horn_sound, PLATFORM_MAX_PATH);
 		if (this.horn_sound[0] != '\0')
 		{
 			char filepath[PLATFORM_MAX_PATH];

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -28,7 +28,7 @@
 
 #define PLUGIN_VERSION	"2.0.0"
 #define PLUGIN_AUTHOR	"Mikusch"
-#define PLUGIN_URL		"https://github.com/Mikusch/mp-vehicles"
+#define PLUGIN_URL		"https://github.com/Mikusch/source-vehicles"
 
 #define VEHICLE_CLASSNAME	"prop_vehicle_driveable"
 

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -26,7 +26,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.9.0"
+#define PLUGIN_VERSION	"2.0.0"
 #define PLUGIN_AUTHOR	"Mikusch"
 #define PLUGIN_URL		"https://github.com/Mikusch/mp-vehicles"
 

--- a/addons/sourcemod/translations/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/vehicles.phrases.txt
@@ -13,7 +13,7 @@
 	"#Menu_Title_Main"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"Driveable Team Fortress 2 Vehicles ({1}) by {2}\n{3}"
+		"en"		"Driveable Vehicles ({1}) by {2}\n{3}"
 	}
 	
 	"#Menu_Title_CreateVehicle"


### PR DESCRIPTION
Related issue: #17

Adds support for Counter-Strike: Source to the plugin.
The general goal of this PR is to generalize the plugin and allow more games to be supported.

**To Do:**
* Make sure no mod-specific files and identifiers are being referenced inside the code and configuration files
* Rebrand the plugin and rename the repository since "tf-vehicles" is no longer a fitting name
* Check if more games can be supported without having to dig for signatures