### PR TITLE
Command and native overhaul

### DIFF
--- a/addons/sourcemod/scripting/include/vehicles.inc
+++ b/addons/sourcemod/scripting/include/vehicles.inc
@@ -28,20 +28,9 @@ methodmap Vehicle
 	}
 	
 	/**
-	 * The entity index.
-	 */
-	property int Entity
-	{
-		public get()
-		{
-			return view_as<int>(this);
-		}
-	}
-	
-	/**
 	 * The owner entity of this vehicle.
 	 *
-	 * @note You should use this property over m_hOwnerEntity if you want the owner to collide with the vehicle.
+	 * This property is an alternative to m_hOwnerEntity that still allows the owner to collide with the vehicle.
 	 */
 	property int Owner
 	{
@@ -50,47 +39,63 @@ methodmap Vehicle
 	}
 	
 	/**
-	 * Creates a new vehicle and spawns it.
+	 * Retrieves the identifier of this vehicle.
 	 *
-	 * @param id		The identifier of the vehicle to spawn, as defined in the configuration.
-	 * @param origin	Origin to spawn vehicle at.
-	 * @param angles	Angles to spawn vehicle at.
-	 * @param owner		The owner entity of this vehicle.
+	 * The identifier is retrieved from the vehicle configuration using the vehicle model and the vehicle script.
 	 *
-	 * @return			Entity index of the vehicle.
+	 * @param buffer		Buffer to store the identifier in.
+	 * @param maxlength		Maximum size of the buffer.
+	 * @return				True on success, false on failure.
 	 */
-	public static native int Create(const char[] id, const float origin[3], const float angles[3], int owner = 0);
+	public native bool GetId(char[] buffer, int maxlength);
 	
 	/**
 	 * Forces a client into this vehicle.
 	 *
-	 * @param	Client index.
+	 * @param client		Client index.
 	 */
 	public native void ForcePlayerIn(int client);
 	
 	/**
-	 * Forces the driver out of this vehicle.
+	 * Forces the current driver out of this vehicle.
 	 */
 	public native void ForcePlayerOut();
 }
 
 /**
- * Called when a vehicle entity has been spawned and fully initialized.
+ * Creates and spawns a new vehicle matching the given identifier.
  *
- * @note It is safe to remove the entity in this forward.
+ * @param id			Identifier of the vehicle, as defined in the configuration.
+ * @param origin		Origin to spawn vehicle at.
+ * @param angles		Angles to spawn vehicle at.
+ * @param owner			Owner entity of this vehicle.
+ * @return				Entity index of the vehicle.
+ */
+native int CreateVehicle(const char[] id, const float origin[3], const float angles[3], int owner = 0);
+
+/**
+ * Retrieves the name of the vehicle with the given identifier.
+ * 
+ * @param id			Identifier of the vehicle, as defined in the configuration.
+ * @param buffer		Buffer to store the name in.
+ * @param maxlength		Maximum size of the buffer.
+ * @return				True on success, false on failure.
+ */
+native bool GetVehicleName(const char[] id, char[] buffer, int maxlength);
+
+/**
+ * Called when a vehicle entity has spawned.
  *
- * @param vehicle	The vehicle entity.
- * @error Invalid vehicle index.
+ * @param vehicle		The vehicle entity.
  */
 forward void OnVehicleSpawned(int vehicle);
 
 /**
- * Called when a vehicle entity is destroyed.
+ * Called when a vehicle entity is being destroyed.
  *
- * @note You should implement this forward over OnEntityDestroyed if you need to access the vehicle's properties.
+ * The vehicle properties can still be accessed in this forward.
  *
- * @param vehicle	The vehicle entity.
- * @error Invalid vehicle index.
+ * @param vehicle		The vehicle entity.
  */
 forward void OnVehicleDestroyed(int vehicle);
 
@@ -110,8 +115,9 @@ public __pl_vehicles_SetNTVOptional()
 {
 	MarkNativeAsOptional("Vehicle.Owner.get");
 	MarkNativeAsOptional("Vehicle.Owner.set");
-	MarkNativeAsOptional("Vehicle.Create");
 	MarkNativeAsOptional("Vehicle.ForcePlayerIn");
 	MarkNativeAsOptional("Vehicle.ForcePlayerOut");
+	MarkNativeAsOptional("CreateVehicle");
+	MarkNativeAsOptional("GetVehicleName");
 }
 #endif

--- a/addons/sourcemod/scripting/include/vehicles.inc
+++ b/addons/sourcemod/scripting/include/vehicles.inc
@@ -28,6 +28,17 @@ methodmap Vehicle
 	}
 	
 	/**
+	 * Creates and spawns a new vehicle matching the given identifier.
+	 *
+	 * @param id			Identifier of the vehicle, as defined in the configuration.
+	 * @param origin		Origin to spawn vehicle at.
+	 * @param angles		Angles to spawn vehicle at.
+	 * @param owner			Owner entity of this vehicle.
+	 * @return				Entity index of the vehicle.
+	 */
+	public static native int Create(const char[] id, const float origin[3], const float angles[3], int owner = 0);
+	
+	/**
 	 * The owner entity of this vehicle.
 	 *
 	 * This property is an alternative to m_hOwnerEntity that still allows the owner to collide with the vehicle.
@@ -63,27 +74,6 @@ methodmap Vehicle
 }
 
 /**
- * Creates and spawns a new vehicle matching the given identifier.
- *
- * @param id			Identifier of the vehicle, as defined in the configuration.
- * @param origin		Origin to spawn vehicle at.
- * @param angles		Angles to spawn vehicle at.
- * @param owner			Owner entity of this vehicle.
- * @return				Entity index of the vehicle.
- */
-native int CreateVehicle(const char[] id, const float origin[3], const float angles[3], int owner = 0);
-
-/**
- * Retrieves the name of the vehicle with the given identifier.
- * 
- * @param id			Identifier of the vehicle, as defined in the configuration.
- * @param buffer		Buffer to store the name in.
- * @param maxlength		Maximum size of the buffer.
- * @return				True on success, false on failure.
- */
-native bool GetVehicleName(const char[] id, char[] buffer, int maxlength);
-
-/**
  * Called when a vehicle entity has spawned.
  *
  * @param vehicle		The vehicle entity.
@@ -99,6 +89,16 @@ forward void OnVehicleSpawned(int vehicle);
  */
 forward void OnVehicleDestroyed(int vehicle);
 
+/**
+ * Retrieves the name of the vehicle with the given identifier.
+ * 
+ * @param id			Identifier of the vehicle, as defined in the configuration.
+ * @param buffer		Buffer to store the name in.
+ * @param maxlength		Maximum size of the buffer.
+ * @return				True on success, false on failure.
+ */
+native bool GetVehicleName(const char[] id, char[] buffer, int maxlength);
+
 public SharedPlugin __pl_vehicles =
 {
 	name = "vehicles",
@@ -113,11 +113,12 @@ public SharedPlugin __pl_vehicles =
 #if !defined REQUIRE_PLUGIN
 public __pl_vehicles_SetNTVOptional()
 {
+	MarkNativeAsOptional("Vehicle.Create");
 	MarkNativeAsOptional("Vehicle.Owner.get");
 	MarkNativeAsOptional("Vehicle.Owner.set");
+	MarkNativeAsOptional("Vehicle.GetId");
 	MarkNativeAsOptional("Vehicle.ForcePlayerIn");
 	MarkNativeAsOptional("Vehicle.ForcePlayerOut");
-	MarkNativeAsOptional("CreateVehicle");
 	MarkNativeAsOptional("GetVehicleName");
 }
 #endif

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -339,9 +339,10 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	
 	CreateNative("Vehicle.Owner.get", NativeCall_VehicleOwnerGet);
 	CreateNative("Vehicle.Owner.set", NativeCall_VehicleOwnerSet);
-	CreateNative("Vehicle.Create", NativeCall_VehicleCreate);
 	CreateNative("Vehicle.ForcePlayerIn", NativeCall_VehicleForcePlayerIn);
 	CreateNative("Vehicle.ForcePlayerOut", NativeCall_VehicleForcePlayerOut);
+	CreateNative("CreateVehicle", NativeCall_CreateVehicle);
+	CreateNative("GetVehicleName", NativeCall_GetVehicleName);
 	
 	g_ForwardOnVehicleSpawned = new GlobalForward("OnVehicleSpawned", ET_Ignore, Param_Cell);
 	g_ForwardOnVehicleDestroyed = new GlobalForward("OnVehicleDestroyed", ET_Ignore, Param_Cell);
@@ -741,34 +742,6 @@ public int NativeCall_VehicleOwnerSet(Handle plugin, int numParams)
 	return Vehicle(vehicle).Owner = owner;
 }
 
-public int NativeCall_VehicleCreate(Handle plugin, int numParams)
-{
-	VehicleConfig config;
-	
-	char id[256];
-	if (GetNativeString(1, id, sizeof(id)) == SP_ERROR_NONE && GetConfigById(id, config))
-	{
-		float origin[3], angles[3];
-		GetNativeArray(2, origin, sizeof(origin));
-		GetNativeArray(3, angles, sizeof(angles));
-		int owner = GetNativeCell(4);
-		
-		int vehicle = CreateVehicle(config, origin, angles, owner);
-		if (vehicle != -1)
-		{
-			return vehicle;
-		}
-		else
-		{
-			return ThrowNativeError(SP_ERROR_NATIVE, "Failed to create vehicle: %s", id);
-		}
-	}
-	else
-	{
-		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid or unknown vehicle: %s", id);
-	}
-}
-
 public int NativeCall_VehicleForcePlayerIn(Handle plugin, int numParams)
 {
 	int vehicle = GetNativeCell(1);
@@ -799,6 +772,39 @@ public int NativeCall_VehicleForcePlayerOut(Handle plugin, int numParams)
 		return;
 	
 	SDKCall_HandlePassengerExit(GetServerVehicle(vehicle), client);
+}
+
+public int NativeCall_CreateVehicle(Handle plugin, int numParams)
+{
+	VehicleConfig config;
+	
+	char id[256];
+	if (GetNativeString(1, id, sizeof(id)) == SP_ERROR_NONE && GetConfigById(id, config))
+	{
+		float origin[3], angles[3];
+		GetNativeArray(2, origin, sizeof(origin));
+		GetNativeArray(3, angles, sizeof(angles));
+		int owner = GetNativeCell(4);
+		
+		int vehicle = CreateVehicle(config, origin, angles, owner);
+		if (vehicle != -1)
+		{
+			return vehicle;
+		}
+		else
+		{
+			return ThrowNativeError(SP_ERROR_NATIVE, "Failed to create vehicle: %s", id);
+		}
+	}
+	else
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid or unknown vehicle: %s", id);
+	}
+}
+
+public int NativeCall_GetVehicleName(Handle plugin, int numParams)
+{
+	//TODO
 }
 
 //-----------------------------------------------------------------------------

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -287,13 +287,13 @@ public void OnPluginStart()
 	vehicle_enable_horns = CreateConVar("vehicle_enable_horns", "1", "If set to 1, enables vehicle horns");
 	
 	RegAdminCmd("sm_vehicle", ConCmd_OpenVehicleMenu, ADMFLAG_GENERIC);
-	RegAdminCmd("sm_vehicles", ConCmd_OpenVehicleMenu, ADMFLAG_GENERIC);
-	RegAdminCmd("sm_createvehicle", ConCmd_CreateVehicle, ADMFLAG_GENERIC);
-	RegAdminCmd("sm_spawnvehicle", ConCmd_CreateVehicle, ADMFLAG_GENERIC);
-	RegAdminCmd("sm_destroyvehicle", ConCmd_DestroyVehicle, ADMFLAG_GENERIC);
-	RegAdminCmd("sm_removevehicle", ConCmd_DestroyVehicle, ADMFLAG_GENERIC);
-	RegAdminCmd("sm_destroyallvehicles", ConCmd_DestroyAllVehicles, ADMFLAG_GENERIC);
-	RegAdminCmd("sm_removeallvehicles", ConCmd_DestroyAllVehicles, ADMFLAG_GENERIC);
+	RegAdminCmd("sm_vehicle_menu", ConCmd_OpenVehicleMenu, ADMFLAG_GENERIC);
+	RegAdminCmd("sm_vehicle_create", ConCmd_CreateVehicle, ADMFLAG_GENERIC);
+	RegAdminCmd("sm_vehicle_spawn", ConCmd_CreateVehicle, ADMFLAG_GENERIC);
+	RegAdminCmd("sm_vehicle_remove", ConCmd_DestroyVehicle, ADMFLAG_GENERIC);
+	RegAdminCmd("sm_vehicle_destroy", ConCmd_DestroyVehicle, ADMFLAG_GENERIC);
+	RegAdminCmd("sm_vehicle_removeall", ConCmd_DestroyAllVehicles, ADMFLAG_GENERIC);
+	RegAdminCmd("sm_vehicle_destroyall", ConCmd_DestroyAllVehicles, ADMFLAG_GENERIC);
 	
 	AddCommandListener(CommandListener_VoiceMenu, "voicemenu");
 	
@@ -1101,12 +1101,12 @@ public int MenuHandler_MainVehicleMenu(Menu menu, MenuAction action, int param1,
 				}
 				else if (StrEqual(info, "vehicle_destroy"))
 				{
-					FakeClientCommand(param1, "sm_destroyvehicle");
+					FakeClientCommand(param1, "sm_vehicle_destroy");
 					DisplayMainVehicleMenu(param1);
 				}
 				else if (StrEqual(info, "vehicle_destroyall"))
 				{
-					FakeClientCommand(param1, "sm_destroyallvehicles");
+					FakeClientCommand(param1, "sm_vehicle_destroyall");
 					DisplayMainVehicleMenu(param1);
 				}
 			}
@@ -1158,7 +1158,7 @@ public int MenuHandler_VehicleCreateMenu(Menu menu, MenuAction action, int param
 			char info[32];
 			if (menu.GetItem(param2, info, sizeof(info)))
 			{
-				FakeClientCommand(param1, "sm_createvehicle %s", info);
+				FakeClientCommand(param1, "sm_vehicle_create %s", info);
 				DisplayVehicleCreateMenu(param1);
 			}
 		}

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -16,9 +16,9 @@
  */
 
 #include <sourcemod>
-#include <dhooks>
 #include <sdkhooks>
 #include <adminmenu>
+#include <dhooks>
 
 #undef REQUIRE_EXTENSIONS
 #tryinclude <loadsoundscript>

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -27,7 +27,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"2.2.0"
+#define PLUGIN_VERSION	"2.3.0"
 #define PLUGIN_AUTHOR	"Mikusch"
 #define PLUGIN_URL		"https://github.com/Mikusch/source-vehicles"
 
@@ -1150,7 +1150,6 @@ public void PropVehicleDriveable_SpawnPost(int vehicle)
 
 void DisplayMainVehicleMenu(int client)
 {
-	//TODO: Make this menu a topmenu!
 	Menu menu = new Menu(MenuHandler_MainVehicleMenu, MenuAction_Select | MenuAction_DisplayItem | MenuAction_End);
 	menu.SetTitle("%t", "#Menu_Title_Main", PLUGIN_VERSION, PLUGIN_AUTHOR, PLUGIN_URL);
 	

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -755,7 +755,7 @@ public int NativeCall_VehicleForcePlayerIn(Handle plugin, int numParams)
 	if (!IsEntityVehicle(vehicle))
 		ThrowNativeError(SP_ERROR_NATIVE, "Entity %d is not a vehicle", vehicle);
 	
-	if (client < 1 || client > MaxClients)
+	if (!IsEntityClient(client))
 		ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d", client);
 	
 	if (!IsClientInGame(client))
@@ -1056,7 +1056,7 @@ public Action PropVehicleDriveable_Use(int vehicle, int activator, int caller, U
 {
 	//Prevent call to ResetUseKey and HandlePassengerEntry for the driving player
 	int driver = GetEntPropEnt(vehicle, Prop_Data, "m_hPlayer");
-	if (0 < activator <= MaxClients && driver != -1 && driver == activator)
+	if (IsEntityClient(activator) && driver != -1 && driver == activator)
 		return Plugin_Handled;
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -1150,9 +1150,9 @@ public void PropVehicleDriveable_SpawnPost(int vehicle)
 
 void DisplayMainVehicleMenu(int client)
 {
+	//TODO: Make this menu a topmenu!
 	Menu menu = new Menu(MenuHandler_MainVehicleMenu, MenuAction_Select | MenuAction_DisplayItem | MenuAction_End);
 	menu.SetTitle("%t", "#Menu_Title_Main", PLUGIN_VERSION, PLUGIN_AUTHOR, PLUGIN_URL);
-	menu.ExitButton = true;
 	
 	if (CheckCommandAccess(client, "sm_vehicle_create", ADMFLAG_GENERIC))
 		menu.AddItem("vehicle_create", "#Menu_Item_CreateVehicle");
@@ -1173,6 +1173,7 @@ void DisplayRemoveVehicleTargetMenu(int client)
 {
 	Menu menu = new Menu(MenuHandler_RemoveVehicles, MenuAction_Select | MenuAction_End);
 	menu.SetTitle("%t", "#Menu_Title_RemovePlayerVehicles");
+	menu.ExitBackButton = true;
 	
 	AddTargetsToMenu(menu, client);
 	
@@ -1231,7 +1232,6 @@ void DisplayVehicleCreateMenu(int client)
 {
 	Menu menu = new Menu(MenuHandler_VehicleCreateMenu, MenuAction_Select | MenuAction_DisplayItem | MenuAction_Cancel | MenuAction_End);
 	menu.SetTitle("%t", "#Menu_Title_CreateVehicle");
-	menu.ExitButton = true;
 	menu.ExitBackButton = true;
 	
 	for (int i = 0; i < g_AllVehicles.Length; i++)

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -979,10 +979,6 @@ public Action ConCmd_RemoveAimTargetVehicle(int client, int args)
 			ReplyToCommand(client, "%t", "Unable to target");
 		}
 	}
-	else
-	{
-		ReplyToCommand(client, "%t", "#Command_RemoveVehicle_NoVehicleFound");
-	}
 	
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -276,7 +276,7 @@ public void OnPluginStart()
 	
 	//Create plugin convars
 	vehicle_config_path = CreateConVar("vehicle_config_path", "configs/vehicles/vehicles.cfg", "Path to vehicle configuration file, relative to the SourceMod folder");
-	vehicle_config_path.AddChangeHook(ConVarChanged_RefreshVehicleConfig);
+	vehicle_config_path.AddChangeHook(ConVarChanged_ReloadVehicleConfig);
 	vehicle_physics_damage_modifier = CreateConVar("vehicle_physics_damage_modifier", "1.0", "Modifier of impact-based physics damage against other players", _, true, 0.0);
 	vehicle_passenger_damage_modifier = CreateConVar("vehicle_passenger_damage_modifier", "1.0", "Modifier of damage dealt to vehicle passengers", _, true, 0.0);
 	vehicle_enable_entry_exit_anims = CreateConVar("vehicle_enable_entry_exit_anims", "0", "If set to 1, enables entry and exit animations (experimental)");
@@ -287,6 +287,7 @@ public void OnPluginStart()
 	RegAdminCmd("sm_vehicle_remove", ConCmd_RemovePlayerVehicles, ADMFLAG_GENERIC, "Remove player vehicles");
 	RegAdminCmd("sm_vehicle_removeaim", ConCmd_RemoveAimTargetVehicle, ADMFLAG_GENERIC, "Remove vehicle at crosshair");
 	RegAdminCmd("sm_vehicle_removeall", ConCmd_RemoveAllVehicles, ADMFLAG_GENERIC, "Remove all vehicles");
+	RegAdminCmd("sm_vehicle_reload", ConCmd_ReloadVehicleConfig, ADMFLAG_GENERIC, "Reload vehicle configuration");
 	
 	AddCommandListener(CommandListener_VoiceMenu, "voicemenu");
 	
@@ -719,7 +720,7 @@ void RestoreConVar(const char[] name, const char[] oldValue)
 // ConVars
 //-----------------------------------------------------------------------------
 
-public void ConVarChanged_RefreshVehicleConfig(ConVar convar, const char[] oldValue, const char[] newValue)
+public void ConVarChanged_ReloadVehicleConfig(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	ReadVehicleConfig();
 }
@@ -1025,6 +1026,14 @@ public Action ConCmd_RemoveAllVehicles(int client, int args)
 	return Plugin_Handled;
 }
 
+public Action ConCmd_ReloadVehicleConfig(int client, int args)
+{
+	ReadVehicleConfig();
+	
+	ShowActivity2(client, "[SM] ", "%t", "#Command_ReloadVehicleConfig_Success");
+	return Plugin_Handled;
+}
+
 public Action CommandListener_VoiceMenu(int client, const char[] command, int args)
 {
 	char arg1[2], arg2[2];
@@ -1165,6 +1174,9 @@ void DisplayMainVehicleMenu(int client)
 	if (CheckCommandAccess(client, "sm_vehicle_removeall", ADMFLAG_GENERIC))
 		menu.AddItem("vehicle_removeall", "#Menu_Item_RemoveAllVehicles");
 	
+	if (CheckCommandAccess(client, "sm_vehicle_reload", ADMFLAG_GENERIC))
+		menu.AddItem("vehicle_reload", "#Menu_Item_ReloadVehicleConfig");
+	
 	menu.Display(client, MENU_TIME_FOREVER);
 }
 
@@ -1204,6 +1216,11 @@ public int MenuHandler_MainVehicleMenu(Menu menu, MenuAction action, int param1,
 				else if (StrEqual(info, "vehicle_removeall"))
 				{
 					FakeClientCommand(param1, "sm_vehicle_removeall");
+					DisplayMainVehicleMenu(param1);
+				}
+				else if (StrEqual(info, "vehicle_reload"))
+				{
+					FakeClientCommand(param1, "sm_vehicle_reload");
 					DisplayMainVehicleMenu(param1);
 				}
 			}

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -337,11 +337,12 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 {
 	RegPluginLibrary("vehicles");
 	
+	CreateNative("Vehicle.Create", NativeCall_VehicleCreate);
 	CreateNative("Vehicle.Owner.get", NativeCall_VehicleOwnerGet);
 	CreateNative("Vehicle.Owner.set", NativeCall_VehicleOwnerSet);
+	CreateNative("Vehicle.GetId", NativeCall_VehicleGetId);
 	CreateNative("Vehicle.ForcePlayerIn", NativeCall_VehicleForcePlayerIn);
 	CreateNative("Vehicle.ForcePlayerOut", NativeCall_VehicleForcePlayerOut);
-	CreateNative("CreateVehicle", NativeCall_CreateVehicle);
 	CreateNative("GetVehicleName", NativeCall_GetVehicleName);
 	
 	g_ForwardOnVehicleSpawned = new GlobalForward("OnVehicleSpawned", ET_Ignore, Param_Cell);
@@ -726,6 +727,34 @@ public void ConVarChanged_RefreshVehicleConfig(ConVar convar, const char[] oldVa
 // Natives
 //-----------------------------------------------------------------------------
 
+public int NativeCall_VehicleCreate(Handle plugin, int numParams)
+{
+	VehicleConfig config;
+	
+	char id[256];
+	if (GetNativeString(1, id, sizeof(id)) == SP_ERROR_NONE && GetConfigById(id, config))
+	{
+		float origin[3], angles[3];
+		GetNativeArray(2, origin, sizeof(origin));
+		GetNativeArray(3, angles, sizeof(angles));
+		int owner = GetNativeCell(4);
+		
+		int vehicle = CreateVehicle(config, origin, angles, owner);
+		if (vehicle != -1)
+		{
+			return vehicle;
+		}
+		else
+		{
+			return ThrowNativeError(SP_ERROR_NATIVE, "Failed to create vehicle: %s", id);
+		}
+	}
+	else
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid or unknown vehicle: %s", id);
+	}
+}
+
 public int NativeCall_VehicleOwnerGet(Handle plugin, int numParams)
 {
 	int vehicle = GetNativeCell(1);
@@ -745,6 +774,23 @@ public int NativeCall_VehicleOwnerSet(Handle plugin, int numParams)
 		ThrowNativeError(SP_ERROR_NATIVE, "Entity %d is not a vehicle", vehicle);
 	
 	return Vehicle(vehicle).Owner = owner;
+}
+
+public int NativeCall_VehicleGetId(Handle plugin, int numParams)
+{
+	int vehicle = GetNativeCell(1);
+	int maxlength = GetNativeCell(3);
+	
+	if (!IsEntityVehicle(vehicle))
+		ThrowNativeError(SP_ERROR_NATIVE, "Entity %d is not a vehicle", vehicle);
+	
+	VehicleConfig config;
+	if (GetConfigByVehicleEnt(vehicle, config))
+	{
+		return SetNativeString(2, config.id, maxlength) == SP_ERROR_NONE;
+	}
+	
+	return false;
 }
 
 public int NativeCall_VehicleForcePlayerIn(Handle plugin, int numParams)
@@ -779,37 +825,20 @@ public int NativeCall_VehicleForcePlayerOut(Handle plugin, int numParams)
 	SDKCall_HandlePassengerExit(GetServerVehicle(vehicle), client);
 }
 
-public int NativeCall_CreateVehicle(Handle plugin, int numParams)
+public int NativeCall_GetVehicleName(Handle plugin, int numParams)
 {
 	VehicleConfig config;
 	
 	char id[256];
 	if (GetNativeString(1, id, sizeof(id)) == SP_ERROR_NONE && GetConfigById(id, config))
 	{
-		float origin[3], angles[3];
-		GetNativeArray(2, origin, sizeof(origin));
-		GetNativeArray(3, angles, sizeof(angles));
-		int owner = GetNativeCell(4);
-		
-		int vehicle = CreateVehicle(config, origin, angles, owner);
-		if (vehicle != -1)
-		{
-			return vehicle;
-		}
-		else
-		{
-			return ThrowNativeError(SP_ERROR_NATIVE, "Failed to create vehicle: %s", id);
-		}
+		int maxlength = GetNativeCell(3);
+		return SetNativeString(2, config.name, maxlength) == SP_ERROR_NONE;
 	}
 	else
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid or unknown vehicle: %s", id);
 	}
-}
-
-public int NativeCall_GetVehicleName(Handle plugin, int numParams)
-{
-	//TODO
 }
 
 //-----------------------------------------------------------------------------

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -835,7 +835,8 @@ public int NativeCall_GetVehicleName(Handle plugin, int numParams)
 	if (GetNativeString(1, id, sizeof(id)) == SP_ERROR_NONE && GetConfigById(id, config))
 	{
 		int maxlength = GetNativeCell(3);
-		return SetNativeString(2, config.name, maxlength) == SP_ERROR_NONE;
+		int bytes;
+		return SetNativeString(2, config.name, maxlength, _, bytes) == SP_ERROR_NONE && bytes > 0;
 	}
 	else
 	{

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -553,6 +553,11 @@ void V_swap(int &x, int &y)
 	y = temp;
 }
 
+bool IsEntityClient(int client)
+{
+	return 0 < client <= MaxClients;
+}
+
 bool IsEntityVehicle(int entity)
 {
 	char classname[32];
@@ -929,7 +934,7 @@ public Action ConCmd_RemovePlayerVehicles(int client, int args)
 	while ((vehicle = FindEntityByClassname(vehicle, VEHICLE_CLASSNAME)) != -1)
 	{
 		int owner = Vehicle(vehicle).Owner;
-		if (owner <= 0)
+		if (!IsEntityClient(owner))
 			continue;
 		
 		for (int i = 0; i < target_count; i++)
@@ -964,7 +969,7 @@ public Action ConCmd_RemoveAimTargetVehicle(int client, int args)
 	if (IsEntityVehicle(entity))
 	{
 		int owner = Vehicle(entity).Owner;
-		if (owner <= 0 || CanUserTarget(client, owner))
+		if (!IsEntityClient(owner) || CanUserTarget(client, owner))
 		{
 			RemoveEntity(entity);
 			ShowActivity2(client, "[SM] ", "%t", "#Command_RemoveVehicle_Success");

--- a/addons/sourcemod/translations/ru/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/ru/vehicles.phrases.txt
@@ -2,68 +2,79 @@
 {
 	"#Hint_VehicleKeys_Car"
 	{
-		"ru"	"%%+speed%% - ГАЗ %%+jump%% - РУЧНОЙ ТОРМОЗ"
+		"ru"		"%%+speed%% - ГАЗ %%+jump%% - РУЧНОЙ ТОРМОЗ"
 	}
 	
 	"#Hint_VehicleKeys_Airboat"
 	{
-		"ru"	"%%+forward%% УСКОРЕНИЕ %%+back%% ТОРМОЗ %%+moveleft%% НАЛЕВО %%+moveright%% НАПРАВО"
+		"ru"		"%%+forward%% УСКОРЕНИЕ %%+back%% ТОРМОЗ %%+moveleft%% НАЛЕВО %%+moveright%% НАПРАВО"
 	}
 	
 	"#Menu_Title_Main"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
-		"ru"		"Добро пожаловать в плагин транспорта {1} от {2}\n{3}"
+		"ru"		"Управляемый Транспорт {1} от {2}\n{3}"
 	}
 	
 	"#Menu_Title_CreateVehicle"
 	{
-		"ru"	"Выберите транспорт для создания"
+		"ru"		"Выберите транспортное средство"
 	}
 	
 	"#Menu_Item_CreateVehicle"
 	{
-		"ru"	"Создать транспорт"
+		"ru"		"Создать новое транспортное средств"
 	}
 	
-	"#Menu_Item_DestroyVehicle"
+	"#Menu_Item_RemoveAimTargetVehicle"
 	{
-		"ru"	"Удалить транспорт"
+		"ru"		"Удалить транспортное средство перед вашим прицелом"
 	}
 	
-	"#Menu_Item_DestroyAllVehicles"
+	"#Menu_Item_RemoveMyVehicles"
 	{
-		"ru"	"Удалить весь созданный транспорт"
+		"ru"		"Удалить все собственные транспортные средства"
+	}
+	
+	"#Menu_Item_RemoveAllVehicles"
+	{
+		"ru"		"Удалить все транспортные средства на сервере"
 	}
 	
 	"#Command_CreateVehicle_Invalid"
 	{
 		"#format"	"{1:s}"
-		"ru"		"Транспортное средство с названием \"{1}\" не найдено."
+		"ru"		"Транспортное средство с названием '{1}' не найдено."
 	}
 	
-	"#Command_DestroyVehicle_Success"
+	"#Command_RemoveVehicle_Success"
 	{
-		"ru"	"Транспортное средство у вашего прицела успешно удалено."
+		"ru"		"Транспортное средство перед вашим прицелом успешно удалено."
 	}
 	
-	"#Command_DestroyVehicle_NoVehicleFound"
+	"#Command_RemoveVehicle_NoVehicleFound"
 	{
-		"ru"	"Нет подходящего транспортного средства для удаления."
+		"ru"		"Перед вашим прицелом нет подходящего транспортного средства."
 	}
 	
-	"#Command_DestroyAllVehicles_Success"
+	"#Command_RemovePlayerVehicles_Success"
 	{
-		"ru"	"Успешно удалены все транспортные средства с карты."
+		"#format"	"{1:t}"
+		"ru"		"Все транспортные средства {1} успешно удалены."
+	}
+	
+	"#Command_RemoveAllVehicles_Success"
+	{
+		"ru"		"Все транспортные средства на сервере успешно удалены."
 	}
 	
 	"#Vehicle_HL2_Jeep"
 	{
-		"ru"	"Багги Half-Life 2"
+		"ru"		"Багги : Half-Life 2"
 	}
 	
 	"#Vehicle_HL2_Airboat"
 	{
-		"ru"	"Катер на воздушной подушке Half-Life 2"
+		"ru"		"Катер на воздушной подушке : Half-Life 2"
 	}
 }

--- a/addons/sourcemod/translations/ru/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/ru/vehicles.phrases.txt
@@ -31,9 +31,9 @@
 		"ru"		"Удалить транспортное средство перед вашим прицелом"
 	}
 	
-	"#Menu_Item_RemoveMyVehicles"
+	"#Menu_Item_RemovePlayerVehicles"
 	{
-		"ru"		"Удалить все собственные транспортные средства"
+		"ru"		"Удалить чужие автомобили"
 	}
 	
 	"#Menu_Item_RemoveAllVehicles"

--- a/addons/sourcemod/translations/ru/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/ru/vehicles.phrases.txt
@@ -23,17 +23,17 @@
 	
 	"#Menu_Item_CreateVehicle"
 	{
-		"ru"	"Создать транспорт (!createvehicle)"
+		"ru"	"Создать транспорт"
 	}
 	
 	"#Menu_Item_DestroyVehicle"
 	{
-		"ru"	"Удалить транспорт (!removevehicle)"
+		"ru"	"Удалить транспорт"
 	}
 	
 	"#Menu_Item_DestroyAllVehicles"
 	{
-		"ru"	"Удалить весь созданный транспорт (!removeallvehicles)"
+		"ru"	"Удалить весь созданный транспорт"
 	}
 	
 	"#Command_CreateVehicle_Invalid"

--- a/addons/sourcemod/translations/ru/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/ru/vehicles.phrases.txt
@@ -52,11 +52,6 @@
 		"ru"		"Транспортное средство перед вашим прицелом успешно удалено."
 	}
 	
-	"#Command_RemoveVehicle_NoVehicleFound"
-	{
-		"ru"		"Перед вашим прицелом нет подходящего транспортного средства."
-	}
-	
 	"#Command_RemovePlayerVehicles_Success"
 	{
 		"#format"	"{1:t}"

--- a/addons/sourcemod/translations/ru/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/ru/vehicles.phrases.txt
@@ -1,15 +1,5 @@
 "Phrases"
 {
-	"#Hint_VehicleKeys_Car"
-	{
-		"ru"		"%%+speed%% - ГАЗ %%+jump%% - РУЧНОЙ ТОРМОЗ"
-	}
-	
-	"#Hint_VehicleKeys_Airboat"
-	{
-		"ru"		"%%+forward%% УСКОРЕНИЕ %%+back%% ТОРМОЗ %%+moveleft%% НАЛЕВО %%+moveright%% НАПРАВО"
-	}
-	
 	"#Menu_Title_Main"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
@@ -71,5 +61,15 @@
 	"#Vehicle_HL2_Airboat"
 	{
 		"ru"		"Катер на воздушной подушке : Half-Life 2"
+	}
+	
+	"#Hint_VehicleKeys_Car"
+	{
+		"ru"		"%%+speed%% - ГАЗ %%+jump%% - РУЧНОЙ ТОРМОЗ"
+	}
+	
+	"#Hint_VehicleKeys_Airboat"
+	{
+		"ru"		"%%+forward%% УСКОРЕНИЕ %%+back%% ТОРМОЗ %%+moveleft%% НАЛЕВО %%+moveright%% НАПРАВО"
 	}
 }

--- a/addons/sourcemod/translations/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/vehicles.phrases.txt
@@ -52,11 +52,6 @@
 		"en"		"Removed the vehicle at their crosshair."
 	}
 	
-	"#Command_RemoveVehicle_NoVehicleFound"
-	{
-		"en"		"Not looking at any valid vehicle to remove."
-	}
-	
 	"#Command_RemovePlayerVehicles_Success"
 	{
 		"#format"	"{1:t}"

--- a/addons/sourcemod/translations/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/vehicles.phrases.txt
@@ -2,12 +2,12 @@
 {
 	"#Hint_VehicleKeys_Car"
 	{
-		"en"	"%%+speed%% TURBO %%+jump%% HANDBRAKE"
+		"en"		"%%+speed%% TURBO %%+jump%% HANDBRAKE"
 	}
 	
 	"#Hint_VehicleKeys_Airboat"
 	{
-		"en"	"%%+forward%% SPEED UP %%+back%% SLOW DOWN %%+moveleft%% TURN LEFT %%+moveright%% TURN RIGHT"
+		"en"		"%%+forward%% SPEED UP %%+back%% SLOW DOWN %%+moveleft%% TURN LEFT %%+moveright%% TURN RIGHT"
 	}
 	
 	"#Menu_Title_Main"
@@ -18,22 +18,27 @@
 	
 	"#Menu_Title_CreateVehicle"
 	{
-		"en"	"Select a vehicle to spawn"
+		"en"		"Select a vehicle to spawn"
 	}
 	
 	"#Menu_Item_CreateVehicle"
 	{
-		"en"	"Create new vehicle"
+		"en"		"Spawn new vehicle"
 	}
 	
-	"#Menu_Item_DestroyVehicle"
+	"#Menu_Item_RemoveAimTargetVehicle"
 	{
-		"en"	"Remove vehicle at crosshair"
+		"en"		"Remove vehicle at crosshair"
 	}
 	
-	"#Menu_Item_DestroyAllVehicles"
+	"#Menu_Item_RemoveMyVehicles"
 	{
-		"en"	"Remove all vehicles in the world"
+		"en"		"Remove your vehicles"
+	}
+	
+	"#Menu_Item_RemoveAllVehicles"
+	{
+		"en"		"Remove all vehicles"
 	}
 	
 	"#Command_CreateVehicle_Invalid"
@@ -42,28 +47,34 @@
 		"en"		"Invalid or unknown vehicle: {1}"
 	}
 	
-	"#Command_DestroyVehicle_Success"
+	"#Command_RemoveVehicle_Success"
 	{
-		"en"	"Successfully removed the vehicle at your crosshair."
+		"en"		"Removed the vehicle at their crosshair."
 	}
 	
-	"#Command_DestroyVehicle_NoVehicleFound"
+	"#Command_RemoveVehicle_NoVehicleFound"
 	{
-		"en"	"Not looking at any valid vehicle to remove."
+		"en"		"Not looking at any valid vehicle to remove."
 	}
 	
-	"#Command_DestroyAllVehicles_Success"
+	"#Command_RemovePlayerVehicles_Success"
 	{
-		"en"	"Successfully removed all vehicles in the map."
+		"#format"	"{1:t}"
+		"en"		"Removed all vehicles of {1}."
+	}
+	
+	"#Command_RemoveAllVehicles_Success"
+	{
+		"en"		"Removed all vehicles in the world."
 	}
 	
 	"#Vehicle_HL2_Jeep"
 	{
-		"en"	"Half-Life 2 Jeep"
+		"en"		"Half-Life 2 Jeep"
 	}
 	
 	"#Vehicle_HL2_Airboat"
 	{
-		"en"	"Half-Life 2 Airboat"
+		"en"		"Half-Life 2 Airboat"
 	}
 }

--- a/addons/sourcemod/translations/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/vehicles.phrases.txt
@@ -23,17 +23,17 @@
 	
 	"#Menu_Item_CreateVehicle"
 	{
-		"en"	"Spawn vehicle (!createvehicle)"
+		"en"	"Create new vehicle"
 	}
 	
 	"#Menu_Item_DestroyVehicle"
 	{
-		"en"	"Remove vehicle (!removevehicle)"
+		"en"	"Remove vehicle at crosshair"
 	}
 	
 	"#Menu_Item_DestroyAllVehicles"
 	{
-		"en"	"Remove all vehicles (!removeallvehicles)"
+		"en"	"Remove all vehicles in the world"
 	}
 	
 	"#Command_CreateVehicle_Invalid"

--- a/addons/sourcemod/translations/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/vehicles.phrases.txt
@@ -1,15 +1,5 @@
 "Phrases"
 {
-	"#Hint_VehicleKeys_Car"
-	{
-		"en"		"%%+speed%% TURBO %%+jump%% HANDBRAKE"
-	}
-	
-	"#Hint_VehicleKeys_Airboat"
-	{
-		"en"		"%%+forward%% SPEED UP %%+back%% SLOW DOWN %%+moveleft%% TURN LEFT %%+moveright%% TURN RIGHT"
-	}
-	
 	"#Menu_Title_Main"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
@@ -18,7 +8,12 @@
 	
 	"#Menu_Title_CreateVehicle"
 	{
-		"en"		"Select a vehicle to spawn"
+		"en"		"Spawn new vehicle:"
+	}
+	
+	"#Menu_Title_RemovePlayerVehicles"
+	{
+		"en"		"Remove player vehicles:"
 	}
 	
 	"#Menu_Item_CreateVehicle"
@@ -33,7 +28,7 @@
 	
 	"#Menu_Item_RemovePlayerVehicles"
 	{
-		"en"		"Remove player's vehicles"
+		"en"		"Remove player vehicles"
 	}
 	
 	"#Menu_Item_RemoveAllVehicles"
@@ -71,5 +66,15 @@
 	"#Vehicle_HL2_Airboat"
 	{
 		"en"		"Half-Life 2 Airboat"
+	}
+	
+	"#Hint_VehicleKeys_Car"
+	{
+		"en"		"%%+speed%% TURBO %%+jump%% HANDBRAKE"
+	}
+	
+	"#Hint_VehicleKeys_Airboat"
+	{
+		"en"		"%%+forward%% SPEED UP %%+back%% SLOW DOWN %%+moveleft%% TURN LEFT %%+moveright%% TURN RIGHT"
 	}
 }

--- a/addons/sourcemod/translations/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/vehicles.phrases.txt
@@ -31,9 +31,9 @@
 		"en"		"Remove vehicle at crosshair"
 	}
 	
-	"#Menu_Item_RemoveMyVehicles"
+	"#Menu_Item_RemovePlayerVehicles"
 	{
-		"en"		"Remove your vehicles"
+		"en"		"Remove player's vehicles"
 	}
 	
 	"#Menu_Item_RemoveAllVehicles"

--- a/addons/sourcemod/translations/vehicles.phrases.txt
+++ b/addons/sourcemod/translations/vehicles.phrases.txt
@@ -36,6 +36,11 @@
 		"en"		"Remove all vehicles"
 	}
 	
+	"#Menu_Item_ReloadVehicleConfig"
+	{
+		"en"		"Reload vehicle configuration"
+	}
+	
 	"#Command_CreateVehicle_Invalid"
 	{
 		"#format"	"{1:s}"
@@ -56,6 +61,11 @@
 	"#Command_RemoveAllVehicles_Success"
 	{
 		"en"		"Removed all vehicles in the world."
+	}
+	
+	"#Command_ReloadVehicleConfig_Success"
+	{
+		"en"		"Reloaded the vehicle configuration."
 	}
 	
 	"#Vehicle_HL2_Jeep"


### PR DESCRIPTION
### New commands
* `sm_vehicle_reload` - Reloads the vehicle configuration. Useful if you don't want to reload the plugin every time you've edited the config
* `sm_vehicle_remove` - Remove all vehicles of a player, uses SourceMod targeting

### Changes to existing commands
* All commands have been renamed to follow the `sm_vehicle` naming for consistency
* All commands now properly print their activity to admins
![image](https://user-images.githubusercontent.com/25514044/133112161-3f4837f7-3ebb-4928-93d4-88958bcb49b8.png)

### New natives
* `bool Vehicle.GetId(char[] buffer, int maxlength)` - Retrieves the identifier of this vehicle
* `bool GetVehicleName(const char[] id, char[] buffer, int maxlength)` - Retrieves the name of the vehicle with the given identifier

### Other changes
* Reordered translations to be more consistent
* Various code improvements